### PR TITLE
TST-626 — Update link title to work on Windows screen reader

### DIFF
--- a/templates/components/common/social-links.html
+++ b/templates/components/common/social-links.html
@@ -1,7 +1,7 @@
 {{#if social_media}}
         {{#each social_media}}
         <li>
-            <a href="{{url}}" title="{{#if display_name '==' 'tumblr'}}Tastefullysimple.com{{else}}{{capitalize display_name}}{{/if}}" target="_blank">
+            <a href="{{url}}" title="{{#if display_name '==' 'tumblr'}}Tastefully Simple.com{{else}}{{capitalize display_name}}{{/if}}" target="_blank">
                 <img alt="{{capitalize display_name}}" src="{{cdn 'assets/img/'}}{{display_name}}.png" />
             </a>
         </li>


### PR DESCRIPTION
The saying in  the header logo should be updated in the admin. Just go to Settings > Store Profile > Store display name.

Please, let me know if you want this to be hardcoded instead.